### PR TITLE
swapdmt: Compatibility with wxWidgets 3.0

### DIFF
--- a/python/swapdmt/MainFrame.py
+++ b/python/swapdmt/MainFrame.py
@@ -58,6 +58,9 @@ if wxversion.checkInstalled("2.8"):
 elif wxversion.checkInstalled("2.9"):
     wx_version = "2.9"
     from wx.lib.pubsub import pub
+elif wxversion.checkInstalled("3.0"):
+    wx_version = "3.0"
+    from wx.lib.pubsub import pub
 else:
     print "version of wxpython not supported"
 
@@ -211,7 +214,7 @@ class MainFrame(wx.Frame):
         @param msg: not used
         """ 
         if self._waitfor_startdialog is not None:
-            wx.CallAfter(pub.sendMessage, "close_wait", None)
+            wx.CallAfter(pub.sendMessage, "close_wait", msg=None)
         
            
     def cb_changed_addr(self, msg):
@@ -664,16 +667,16 @@ class BrowserPanel(wx.Panel):
         menu = None
         if obj.__class__.__name__ == "SwapMote":
             menu = wx.Menu()                
-            menu.Append(0, "Network settings")
-            wx.EVT_MENU(menu, 0, self.parent.onMoteNetworkConfig)
+            menu.Append(1, "Network settings")
+            wx.EVT_MENU(menu, 1, self.parent.onMoteNetworkConfig)
             if obj.config_registers is not None:
-                menu.Append(1, "Custom settings")
-                wx.EVT_MENU(menu, 1, self.parent.onConfigDevice)
+                menu.Append(2, "Custom settings")
+                wx.EVT_MENU(menu, 2, self.parent.onConfigDevice)
         elif obj.__class__.__name__ == "SwapRegister":
             if obj.isConfig():
                 menu = wx.Menu()
-                menu.Append(0, "Configure")
-                wx.EVT_MENU(menu, 0, self.parent.onConfigDevice)
+                menu.Append(1, "Configure")
+                wx.EVT_MENU(menu, 1, self.parent.onConfigDevice)
         
         if menu is not None:
             self.PopupMenu(menu, evn.GetPoint())
@@ -1041,8 +1044,8 @@ class SnifferPanel(wx.Panel):
             msgtype = self.log_list.GetItem(index, 1).GetText()
             if msgtype != "ERROR":        
                 menu = wx.Menu()
-                menu.Append(0, "Show details")
-                wx.EVT_MENU(menu, 0, self._cb_on_details)
+                menu.Append(1, "Show details")
+                wx.EVT_MENU(menu, 1, self._cb_on_details)
                 self.PopupMenu(menu, evn.GetPoint())
                 menu.Destroy()
 

--- a/python/swapdmt/SwapManager.py
+++ b/python/swapdmt/SwapManager.py
@@ -42,6 +42,9 @@ if wxversion.checkInstalled("2.8"):
 elif wxversion.checkInstalled("2.9"):
     wx_version = "2.9"
     from wx.lib.pubsub import pub
+elif wxversion.checkInstalled("3.0"):
+    wx_version = "3.0"
+    from wx.lib.pubsub import pub
 else:
     print "version of wxpython not supported"
 
@@ -54,10 +57,10 @@ class SwapManager(SwapInterface):
         """
         SWAP server started successfully
         """
-        wx.CallAfter(pub.sendMessage, "server_started", None)
+        wx.CallAfter(pub.sendMessage, "server_started", msg=None)
 
         # Display event
-        wx.CallAfter(pub.sendMessage, "add_event", "SWAP server started")
+        wx.CallAfter(pub.sendMessage, "add_event", msg="SWAP server started")
         
 
     def swapPacketReceived(self, packet):
@@ -66,7 +69,7 @@ class SwapManager(SwapInterface):
         
         @param packet: SWAP packet received
         """
-        wx.CallAfter(pub.sendMessage, "packet_received", packet)
+        wx.CallAfter(pub.sendMessage, "packet_received", msg=packet)
     
 
     def swapPacketSent(self, packet):
@@ -75,7 +78,7 @@ class SwapManager(SwapInterface):
         
         @param packet: SWAP packet transmitted
         """
-        wx.CallAfter(pub.sendMessage, "packet_sent", packet)
+        wx.CallAfter(pub.sendMessage, "packet_sent", msg=packet)
 
 
     def newMoteDetected(self, mote):
@@ -88,10 +91,10 @@ class SwapManager(SwapInterface):
             # Display event
             evntext = "New mote with address " + str(mote.address) + " : " + mote.definition.product + \
             " (by " + mote.definition.manufacturer + ")"
-            wx.CallAfter(pub.sendMessage, "add_event", evntext)
+            wx.CallAfter(pub.sendMessage, "add_event", msg=evntext)
             
             # Append mote to the browsing tree
-            wx.CallAfter(pub.sendMessage, "add_mote", mote)
+            wx.CallAfter(pub.sendMessage, "add_mote", msg=mote)
 
 
     def newEndpointDetected(self, endpoint):
@@ -103,7 +106,7 @@ class SwapManager(SwapInterface):
         if self.dmtframe is not None:
             # Display event
             evntext = "New endpoint with Reg ID = " + str(endpoint.getRegId()) + " : " + endpoint.name
-            wx.CallAfter(pub.sendMessage, "add_event", evntext)
+            wx.CallAfter(pub.sendMessage, "add_event", msg=evntext)
 
 
     def moteStateChanged(self, mote):
@@ -116,11 +119,11 @@ class SwapManager(SwapInterface):
             # Display event
             evntext = "Mote with address " + str(mote.address) + " switched to \"" + \
                 SwapState.toString(mote.state) + "\""
-            wx.CallAfter(pub.sendMessage, "add_event", evntext)
+            wx.CallAfter(pub.sendMessage, "add_event", msg=evntext)
             
             # SYNC mode entered?
             if mote.state == SwapState.SYNC:
-                wx.CallAfter(pub.sendMessage, "sync_received", mote)
+                wx.CallAfter(pub.sendMessage, "sync_received", msg=mote)
 
 
     def moteAddressChanged(self, mote):
@@ -132,10 +135,10 @@ class SwapManager(SwapInterface):
         if self.dmtframe is not None:
             # Display event
             evntext = "Mote changed address to " + str(mote.address)
-            wx.CallAfter(pub.sendMessage, "add_event", evntext)
+            wx.CallAfter(pub.sendMessage, "add_event", msg=evntext)
                 
             # Update address in tree
-            wx.CallAfter(pub.sendMessage, "changed_addr", mote)
+            wx.CallAfter(pub.sendMessage, "changed_addr", msg=mote)
 
 
     def endpointValueChanged(self, endpoint):
@@ -147,10 +150,10 @@ class SwapManager(SwapInterface):
         if self.dmtframe is not None:
             # Display event
             evntext = endpoint.name + " in address " + str(endpoint.getRegAddress()) + " changed to " + endpoint.getValueInAscii()
-            wx.CallAfter(pub.sendMessage, "add_event", evntext)
+            wx.CallAfter(pub.sendMessage, "add_event", msg=evntext)
 
             # Update value in SWAP dmtframe
-            wx.CallAfter(pub.sendMessage, "changed_val", endpoint)    
+            wx.CallAfter(pub.sendMessage, "changed_val", msg=endpoint)    
 
 
     def parameterValueChanged(self, param):
@@ -162,10 +165,10 @@ class SwapManager(SwapInterface):
         if self.dmtframe is not None:
             # Display event
             evntext = param.name + " in address " + str(param.getRegAddress()) + " changed to " + param.getValueInAscii()
-            wx.CallAfter(pub.sendMessage, "add_event", evntext)
+            wx.CallAfter(pub.sendMessage, "add_event", msg=evntext)
                 
             # Update value in SWAP dmtframe
-            wx.CallAfter(pub.sendMessage, "changed_val", param) 
+            wx.CallAfter(pub.sendMessage, "changed_val", msg=param) 
         
 
     def terminate(self):

--- a/python/swapdmt/WaitDialog.py
+++ b/python/swapdmt/WaitDialog.py
@@ -38,6 +38,9 @@ if wxversion.checkInstalled("2.8"):
 elif wxversion.checkInstalled("2.9"):
     wx_version = "2.9"
     from wx.lib.pubsub import pub
+elif wxversion.checkInstalled("3.0"):
+    wx_version = "3.0"
+    from wx.lib.pubsub import pub
 else:
     print "version of wxpython not supported"
 


### PR DESCRIPTION
For compatibility with wxWidgets 3.0, not only the imports need to be
changed, but also the interface for wx.CallAfter() seems to have
changed. Additionally, a menu index of 0 is invalid on OS X, so start
with the first menu entry at position 1.
