### PR TITLE
firmware: rf: small improvements

### DIFF
--- a/arduino-1.5/arduino-1.5_patch/hardware/panstamp/msp430/bootloaders/rf/Makefile
+++ b/arduino-1.5/arduino-1.5_patch/hardware/panstamp/msp430/bootloaders/rf/Makefile
@@ -46,4 +46,4 @@ clean:
 	-rm -f $(PROG).elf $(PROG).lst $(PROG).hex $(OBJS) *.d *~
 
 flash:
-	$(TOOLCHAIN)gdb -b 38400 -ex 'set debug remote 0' -ex 'target remote /dev/ttyUSB1' $(PROG).elf -ex 'erase' -ex 'load' -ex 'quit'
+	$(TOOLCHAIN)gdb -n -b 38400 -ex 'set debug remote 0' -ex 'target remote /dev/ttyUSB1' $(PROG).elf -ex 'erase' -ex 'load' -ex 'set confirm off' -ex 'quit'


### PR DESCRIPTION
1) add -ex 'set confirm off' to stop gdb from asking if I really want to quit
2) add -n to keep gdb from reading .gdbinit files. Otherwise the command in those files may (negatively) affect the execution of gdb
